### PR TITLE
fix: Correct bash syntax

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ Darwin)
     ;;
 esac
 
-if [ -z $FILE_PREFIX ]; then
+if [ -z "$FILE_PREFIX" ]; then
   if [ $# -eq 0 ]; then
     echo "Usage: $0 [linux-amd64|darwin-arm64|linux-arm64]"
     exit 1
@@ -62,7 +62,7 @@ download_latest_release() {
   local api_url="https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases/tags/$latest_tag_var"
   local releases_info=$(curl -sf "$api_url")
 
-  if [ -z $releases_info ]; then
+  if [ -z "$releases_info" ]; then
     echo "Failed to download $application release information"
     exit 1
   fi

--- a/run.sh
+++ b/run.sh
@@ -81,6 +81,7 @@ download_latest_release() {
     echo "Failed to download the release file"
     exit 1
   fi
+  chmod +x "$application/$download_filename"
   echo "Downloaded $download_filename"
 }
 


### PR DESCRIPTION
```
./run.sh: line 66: [: too many arguments
```

releases_info contains special characters and needs to be properly quoted so Bash handles this correctly. Went ahead and quoted the other conditional check for consistently.