### PR TITLE
Update run.sh to detect cpu arch more consistently

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ if [ -z "$FILE_PREFIX" ]; then
   case $( uname -s ) in
   Linux)
 
-    case $( uname -i ) in
+    case $( uname -m ) in
     x86_64)
       FILE_PREFIX="linux-amd64"
       ;;


### PR DESCRIPTION
use -m instead of -i option for uname, tested on arm64 and x64 arch