### PR TITLE
Update run.sh to deal with bad tags

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -69,15 +69,6 @@ GITHUB_REPO="Dragonite-Public"
 # Fetch the latest tags from the local Git repository
 git fetch --tags
 
-# Check for bad tags
-bad=$(git tag -l | grep -E "v\.")
-if [ ! -z $bad ]; then
-	for i in $bad ; do
-	echo "Found bad tag ${i}...Removing"
-	git tag -d $i
-	done
-fi
-
 # Do we want the testing version?
 if [ "$TESTING" = "true" ]; then
   # Get the latest Testing Git tag for the "dragonite-" prefix

--- a/run.sh
+++ b/run.sh
@@ -81,9 +81,9 @@ fi
 # Do we want the testing version?
 if [ "$TESTING" = "true" ]; then
   # Get the latest Testing Git tag for the "dragonite-" prefix
-  latest_dragonite_tag=$(git tag | grep -E "dragonite-v[0-9]" | sort -V | tail -n 1)
+  latest_dragonite_tag=$(git tag --list| grep "dragonite-v[0-9]" | sort -V | tail -n 1)
   # Get the latest Testing Git tag for the "admin-" prefix
-  latest_admin_tag=$(git tag | grep "admin-v[0-9]" | sort -V | tail -n 1)
+  latest_admin_tag=$(git tag --list | grep "admin-v[0-9]" | sort -V | tail -n 1)
 elif [ ! -z $SHOW_TAGS ] && [ $SHOW_TAGS != "true" ]; then
   # Attempt to get the requested Dragonite tag
   latest_dragonite_tag="${SHOW_TAGS}"
@@ -91,9 +91,9 @@ elif [ ! -z $SHOW_TAGS ] && [ $SHOW_TAGS != "true" ]; then
   latest_admin_tag="${SHOW_TAGS}"
 else
   # Get the latest Production Git tag for the "dragonite-" prefix
-  latest_dragonite_tag=$(git tag --list 'dragonite-v*' | grep -v '\-testing' | sort -V | tail -n 1)
+  latest_dragonite_tag=$(git tag --list | grep "dragonite-v[0-9]" | grep -v '\-testing' | sort -V | tail -n 1)
   # Get the latest Production Git tag for the "admin-" prefix
-  latest_admin_tag=$(git tag --list 'admin-v*' | grep -v '\-testing' | sort -V | tail -n 1)
+  latest_admin_tag=$(git tag --list | grep "admin-v[0-9]" | grep -v '\-testing' | sort -V | tail -n 1)
 fi
 
 download_latest_release() {

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ if [ -z "$FILE_PREFIX" ]; then
   case $( uname -s ) in
   Linux)
 
-    case $( uname -i ) in
+    case $( uname -m ) in
     x86_64)
       FILE_PREFIX="linux-amd64"
       ;;

--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ if [ -z "$FILE_PREFIX" ]; then
   case $( uname -s ) in
   Linux)
 
-    case $( uname -m ) in
+    case $( uname -i ) in
     x86_64)
       FILE_PREFIX="linux-amd64"
       ;;
@@ -69,12 +69,21 @@ GITHUB_REPO="Dragonite-Public"
 # Fetch the latest tags from the local Git repository
 git fetch --tags
 
+# Check for bad tags
+bad=$(git tag -l | grep -E "v\.")
+if [ ! -z $bad ]; then
+	for i in $bad ; do
+	echo "Found bad tag ${i}...Removing"
+	git tag -d $i
+	done
+fi
+
 # Do we want the testing version?
 if [ "$TESTING" = "true" ]; then
   # Get the latest Testing Git tag for the "dragonite-" prefix
-  latest_dragonite_tag=$(git tag --list 'dragonite-v*' | sort -V | tail -n 1)
+  latest_dragonite_tag=$(git tag | grep -E "dragonite-v[0-9]" | sort -V | tail -n 1)
   # Get the latest Testing Git tag for the "admin-" prefix
-  latest_admin_tag=$(git tag --list 'admin-v*' | sort -V | tail -n 1)
+  latest_admin_tag=$(git tag | grep "admin-v[0-9]" | sort -V | tail -n 1)
 elif [ ! -z $SHOW_TAGS ] && [ $SHOW_TAGS != "true" ]; then
   # Attempt to get the requested Dragonite tag
   latest_dragonite_tag="${SHOW_TAGS}"


### PR DESCRIPTION
This PR updates run.sh to not only check for bad tags, but also changes how it grabs tags to use grep with minor regex matching instead of a wildcard.

This should not only fix the bad tags from being picked up, but also ignore them.