### PR TITLE
Add token_refresh_only to config example

### DIFF
--- a/dragonite/config.toml.example
+++ b/dragonite/config.toml.example
@@ -27,6 +27,7 @@ bearer_token = "KOJI_SECRET"
 #location_delay = 0
 #fort_location_delay = 0
 #scout_age_limit = 30
+#token_refresh_only=true
 
 #[accounts]
 #required_level = 30 # used for everything except leveling (quest can force level 31 at specific events)


### PR DESCRIPTION
token_refresh_only provides emergency support for authenticating only with refresh tokens meaning no account modification needed.